### PR TITLE
Remove NC assertion in GPIO object

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC15XX/gpio_object.h
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC15XX/gpio_object.h
@@ -33,7 +33,8 @@ typedef struct {
 } gpio_t;
 
 static inline void gpio_write(gpio_t *obj, int value) {
-    MBED_ASSERT(obj->pin != (PinName)NC);
+    if(obj->pin == (PinName)(NC))
+        return;
 
     if (value)
         *obj->reg_set = obj->mask;


### PR DESCRIPTION
Removed a run-time assertion that can cause crashes despite declaring a GPIO object to be NC being allowed. 

Instead just return. 

This also allows cleaner code for things that where some versions of boards don't have everything connected that others do. Tested this locally with lights over the summer.
